### PR TITLE
Add minimal paint store with calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # sklep
-Strona sklepu
+
+Minimalistyczna strona sklepu z farbami.
+
+## Funkcje
+- Lista przykładowych farb
+- Kalkulator zużycia i kosztu farby
+
+## Uruchomienie
+Otwórz `index.html` w przeglądarce.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8">
+  <title>Sklep z Farbami</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <h1>Minimalistyczny sklep z farbami</h1>
+  </header>
+  <main>
+    <section id="produkty">
+      <h2>Nasze farby</h2>
+      <div class="product-list">
+        <article class="product">
+          <h3>Farba Akrylowa</h3>
+          <p>Cena: 50 zł / litr</p>
+          <button class="buy-button" data-price="50">Kup teraz</button>
+        </article>
+        <article class="product">
+          <h3>Farba Lateksowa</h3>
+          <p>Cena: 70 zł / litr</p>
+          <button class="buy-button" data-price="70">Kup teraz</button>
+        </article>
+      </div>
+    </section>
+    <section id="kalkulator">
+      <h2>Kalkulator farby</h2>
+      <label for="area">Powierzchnia (m²):</label>
+      <input type="number" id="area" min="0" value="0">
+      <label for="coverage">Wydajność (m²/l):</label>
+      <input type="number" id="coverage" min="1" value="10">
+      <label for="price">Cena za litr (zł):</label>
+      <input type="number" id="price" min="0" value="50">
+      <button id="calculate">Oblicz</button>
+      <div id="result"></div>
+    </section>
+  </main>
+  <script src="scripts.js"></script>
+</body>
+</html>

--- a/scripts.js
+++ b/scripts.js
@@ -1,0 +1,24 @@
+document.getElementById('calculate').addEventListener('click', function () {
+  const area = parseFloat(document.getElementById('area').value);
+  const coverage = parseFloat(document.getElementById('coverage').value);
+  const price = parseFloat(document.getElementById('price').value);
+
+  if (isNaN(area) || isNaN(coverage) || isNaN(price) || coverage <= 0) {
+    document.getElementById('result').textContent = 'Podaj prawidłowe wartości.';
+    return;
+  }
+
+  const litersNeeded = Math.ceil((area / coverage) * 100) / 100;
+  const totalCost = Math.round(litersNeeded * price * 100) / 100;
+
+  document.getElementById('result').textContent =
+    `Potrzebujesz ${litersNeeded} l farby, koszt: ${totalCost} zł.`;
+});
+
+document.querySelectorAll('.buy-button').forEach(btn => {
+  btn.addEventListener('click', (e) => {
+    const price = e.target.getAttribute('data-price');
+    document.getElementById('price').value = price;
+    window.scrollTo({ top: document.getElementById('kalkulator').offsetTop, behavior: 'smooth' });
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,37 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 1rem;
+  background: #fdfdfd;
+  color: #333;
+}
+header, section {
+  margin-bottom: 2rem;
+}
+.product-list {
+  display: flex;
+  gap: 1rem;
+}
+.product {
+  border: 1px solid #ccc;
+  padding: 1rem;
+  flex: 1;
+}
+.buy-button {
+  background: #007acc;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+.buy-button:hover {
+  background: #005fa3;
+}
+#kalkulator input {
+  display: block;
+  margin-bottom: 0.5rem;
+}
+#result {
+  margin-top: 1rem;
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- build minimalistic paint shop layout with example products and calculator
- implement JavaScript logic for paint coverage and cost
- add basic styles and update README instructions

## Testing
- `npx -y htmlhint index.html` *(fails: 403 Forbidden)*
- `npx -y eslint scripts.js` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68bad4de8fe083219e485fb7f5d6730b